### PR TITLE
Fix SciPy dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
   "numpy",
   "opencv-python",
   "scikit-image",
+  "scipy",
   "onnxruntime",
   "torch",
   "requests",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 numpy
 opencv-python
 scikit-image
+scipy
 onnxruntime
 torch
 requests

--- a/skizze/deep_lsd_utils.py
+++ b/skizze/deep_lsd_utils.py
@@ -1,6 +1,10 @@
 import numpy as np
 import cv2
-from scipy.ndimage import gaussian_filter
+try:
+    from scipy.ndimage import gaussian_filter
+except Exception:  # pragma: no cover - optional dependency
+    def gaussian_filter(arr, sigma=1.0):
+        return cv2.GaussianBlur(arr, (0, 0), sigma)
 
 def postprocess_attraction_field(attr_field: np.ndarray, orig_h:int, orig_w:int, conf_th:float=0.7):
     g0 = gaussian_filter(attr_field[0], sigma=1.0)


### PR DESCRIPTION
## Summary
- add missing SciPy dependency to pyproject and requirements
- fallback to OpenCV when SciPy is unavailable in deep_lsd_utils

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6843698cc3048327bf9d9e7ba9e61dfe