### PR TITLE
Fix SciPy dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+env/
+__pycache__/
+skizze/__pycache__/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
   "numpy",
   "opencv-python",
   "scikit-image",
+  "scipy",
   "onnxruntime",
   "torch",
   "requests",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 numpy
 opencv-python
 scikit-image
+scipy
 onnxruntime
 torch
 requests

--- a/skizze/cli.py
+++ b/skizze/cli.py
@@ -1,14 +1,22 @@
-import argparse, sys, logging, os, numpy as np, cv2, torch
+import sys
 from pathlib import Path
+
 from .utils import ensure_venv, install_missing_packages, REQUIRED_PACKAGES, setup_logging
+
+ensure_venv()
+install_missing_packages(REQUIRED_PACKAGES)
+
+import argparse
+import logging
+import os
+import numpy as np
+import cv2
+import torch
 from .config import load_config_from_pyproject
 from .preprocessing import load_image, to_grayscale, denoise_image, morphological_opening, morphological_closing
 from .thresholding import auto_threshold_otsu, adaptive_threshold
 from .drawing import draw_lines_on_blank, combine_line_images
 from .line_detection import detect_edges_canny, detect_lines_hough, filter_lines_by_length
-
-ensure_venv()
-install_missing_packages(REQUIRED_PACKAGES)
 setup_logging()
 log = logging.getLogger(__name__)
 cfg = load_config_from_pyproject()

--- a/skizze/deep_lsd_utils.py
+++ b/skizze/deep_lsd_utils.py
@@ -1,6 +1,10 @@
 import numpy as np
 import cv2
-from scipy.ndimage import gaussian_filter
+try:
+    from scipy.ndimage import gaussian_filter
+except Exception:  # pragma: no cover - optional dependency
+    def gaussian_filter(arr, sigma=1.0):
+        return cv2.GaussianBlur(arr, (0, 0), sigma)
 
 def postprocess_attraction_field(attr_field: np.ndarray, orig_h:int, orig_w:int, conf_th:float=0.7):
     g0 = gaussian_filter(attr_field[0], sigma=1.0)

--- a/skizze/utils.py
+++ b/skizze/utils.py
@@ -5,7 +5,6 @@ from pathlib import Path
 import venv
 import hashlib
 import logging
-import requests
 
 # 12.1 Virtual environment
 def ensure_venv():
@@ -62,6 +61,7 @@ def download_model_if_missing(model_url: str, save_path: str, expected_sha256: s
             path.unlink()
         else:
             return
+    import requests
     print(f"🔽 Downloading model from '{model_url}' → '{path}'")
     response = requests.get(model_url, stream=True)
     response.raise_for_status()


### PR DESCRIPTION
## Summary
- add missing SciPy dependency to pyproject and requirements
- fallback to OpenCV when SciPy is unavailable in deep_lsd_utils
- ensure virtual environment automatically sets up before imports
- install required packages before heavy imports
- ignore env/ and __pycache__ folders

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python Skizze.py --help` *(verifies env creation)*


------
https://chatgpt.com/codex/tasks/task_e_6843698cc3048327bf9d9e7ba9e61dfe