### PR TITLE
Fix stray text and clean setup code

### DIFF
--- a/skizze/cli.py
+++ b/skizze/cli.py
@@ -1,11 +1,10 @@
-1h5up9-codex/fehler-im-code-suchen-und-korrigieren
 from pathlib import Path
 import argparse
 import logging
 
 from .utils import ensure_venv, install_missing_packages, REQUIRED_PACKAGES, setup_logging
 
-# configure basic logging first
+# configure environment
 setup_logging()
 ensure_venv()
 install_missing_packages(REQUIRED_PACKAGES)
@@ -39,27 +38,6 @@ from .line_detection import (
 )
 from .scikit_tools import clean_binary_scikit, skeletonize_image
 
-import sys
-from pathlib import Path
-
-from .utils import ensure_venv, install_missing_packages, REQUIRED_PACKAGES, setup_logging
-
-ensure_venv()
-install_missing_packages(REQUIRED_PACKAGES)
-
-import argparse
-import logging
-import os
-import numpy as np
-import cv2
-import torch
-from .config import load_config_from_pyproject
-from .preprocessing import load_image, to_grayscale, denoise_image, morphological_opening, morphological_closing
-from .thresholding import auto_threshold_otsu, adaptive_threshold
-from .drawing import draw_lines_on_blank, combine_line_images
-from .line_detection import detect_edges_canny, detect_lines_hough, filter_lines_by_length
-setup_logging()
-main
 log = logging.getLogger(__name__)
 cfg = load_config_from_pyproject()
 

--- a/skizze/deep_lsd_utils.py
+++ b/skizze/deep_lsd_utils.py
@@ -1,14 +1,8 @@
 import numpy as np
 import cv2
 try:
-    from scipy.ndimage import gaussian_filter
-1h5up9-codex/fehler-im-code-suchen-und-korrigieren
-except ImportError:  # optional dependency
-k7xps3-codex/fehler-im-code-suchen-und-korrigieren
-except ImportError:  # optional dependency
+    from scipy.ndimage import gaussian_filter  # type: ignore
 except Exception:  # pragma: no cover - optional dependency
-main
-main
     def gaussian_filter(arr, sigma=1.0):
         return cv2.GaussianBlur(arr, (0, 0), sigma)
 

--- a/skizze/utils.py
+++ b/skizze/utils.py
@@ -6,10 +6,8 @@ from pathlib import Path
 import venv
 import hashlib
 import logging
-1h5up9-codex/fehler-im-code-suchen-und-korrigieren
 
 logger = logging.getLogger(__name__)
-main
 
 # 12.1 Virtual environment
 def ensure_venv():
@@ -73,10 +71,7 @@ def download_model_if_missing(model_url: str, save_path: str, expected_sha256: s
         else:
             return
     import requests
- 1h5up9-codex/fehler-im-code-suchen-und-korrigieren
     logger.info("🔽 Downloading model from '%s' → '%s'", model_url, path)
-    print(f"🔽 Downloading model from '{model_url}' → '{path}'")
- main
     response = requests.get(model_url, stream=True)
     response.raise_for_status()
     with open(path, "wb") as f:


### PR DESCRIPTION
## Summary
- cleanup stray lines left from earlier merges
- keep venv creation and package installation logic working

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `bash test_run.sh` *(fails: installing heavy packages)*

------
https://chatgpt.com/codex/tasks/task_e_684388319d588327b4a8dbdf7c2873e2